### PR TITLE
feat: Provide an example that connects to a worker's IFrame

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,17 @@ npm start
 ```
 
 Your development server will start up. You can then open up the URL in your browser and you should see a table appear.
+
+### Fetching a Table
+
+At the default URL, it will create a table and display it using an `IrisGrid` component. To open this, simply navigate your browser to the development server URL, which is http://localhost:5173 by default.
+
+You can also fetch a table from a PQ as well. To do this, navigate to http://localhost:5173/?queryName=MyQuery&tableName=myTable where `MyQuery` is the name of the query and `myTable` is the name of the table.
+
+View the source for this width at [src/App.tsx](./src/App.tsx).
+
+## IFrame Example
+
+You can also display a widget from a Core+ worker in an IFrame. To do this, navigate to http://localhost:5173/iframe/?queryName=MyQuery&widgetName=myWidget where `MyQuery` is the name of the query and `myWidget` is the name of the widget.
+
+View the source for this width at [src/IFrameApp.tsx](./src/IFrameApp.tsx).

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,8 +12,10 @@
         "@deephaven/dashboard": "^0.46.0",
         "@deephaven/iris-grid": "^0.46.0",
         "@deephaven/jsapi-shim": "^0.46.0",
+        "@deephaven/jsapi-utils": "^0.46.0",
         "react": "^17.0.2",
-        "react-dom": "^17.0.2"
+        "react-dom": "^17.0.2",
+        "react-router-dom": "^6.24.0"
       },
       "devDependencies": {
         "@types/react": "^17.0.2",
@@ -1571,6 +1573,14 @@
       "integrity": "sha512-h852l8bWhqUxbXIG8vH3ab7gE19nnP3U1kuWf6SNSMvgmqjiRN9jXKPIFxF/PbfdvnXXm0yZSgSMWfUCARF0Cg==",
       "peerDependencies": {
         "react": "^16.8.0 || ^17.0.0-rc.1 || ^18.0.0"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.17.0.tgz",
+      "integrity": "sha512-2D6XaHEVvkCn682XBnipbJjgZUU7xjLtA4dGJRBVUKpEaDYOZMENZoZjAOSb7qirxt5RupjzZxz4fK2FO+EFPw==",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@swc/helpers": {
@@ -5341,6 +5351,36 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "6.24.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.24.0.tgz",
+      "integrity": "sha512-sQrgJ5bXk7vbcC4BxQxeNa5UmboFm35we1AFK0VvQaz9g0LzxEIuLOhHIoZ8rnu9BO21ishGeL9no1WB76W/eg==",
+      "dependencies": {
+        "@remix-run/router": "1.17.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.24.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.24.0.tgz",
+      "integrity": "sha512-960sKuau6/yEwS8e+NVEidYQb1hNjAYM327gjEyXlc6r3Skf2vtwuJ2l7lssdegD2YjoKG5l8MsVyeTDlVeY8g==",
+      "dependencies": {
+        "@remix-run/router": "1.17.0",
+        "react-router": "6.24.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
+      }
+    },
     "node_modules/react-transition-group": {
       "version": "4.4.5",
       "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
@@ -7440,6 +7480,11 @@
       "resolved": "https://registry.npmjs.org/@react-types/shared/-/shared-3.19.0.tgz",
       "integrity": "sha512-h852l8bWhqUxbXIG8vH3ab7gE19nnP3U1kuWf6SNSMvgmqjiRN9jXKPIFxF/PbfdvnXXm0yZSgSMWfUCARF0Cg==",
       "requires": {}
+    },
+    "@remix-run/router": {
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.17.0.tgz",
+      "integrity": "sha512-2D6XaHEVvkCn682XBnipbJjgZUU7xjLtA4dGJRBVUKpEaDYOZMENZoZjAOSb7qirxt5RupjzZxz4fK2FO+EFPw=="
     },
     "@swc/helpers": {
       "version": "0.5.1",
@@ -10378,6 +10423,23 @@
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.14.0.tgz",
       "integrity": "sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==",
       "dev": true
+    },
+    "react-router": {
+      "version": "6.24.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.24.0.tgz",
+      "integrity": "sha512-sQrgJ5bXk7vbcC4BxQxeNa5UmboFm35we1AFK0VvQaz9g0LzxEIuLOhHIoZ8rnu9BO21ishGeL9no1WB76W/eg==",
+      "requires": {
+        "@remix-run/router": "1.17.0"
+      }
+    },
+    "react-router-dom": {
+      "version": "6.24.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.24.0.tgz",
+      "integrity": "sha512-960sKuau6/yEwS8e+NVEidYQb1hNjAYM327gjEyXlc6r3Skf2vtwuJ2l7lssdegD2YjoKG5l8MsVyeTDlVeY8g==",
+      "requires": {
+        "@remix-run/router": "1.17.0",
+        "react-router": "6.24.0"
+      }
     },
     "react-transition-group": {
       "version": "4.4.5",

--- a/package.json
+++ b/package.json
@@ -14,8 +14,10 @@
     "@deephaven/dashboard": "^0.46.0",
     "@deephaven/iris-grid": "^0.46.0",
     "@deephaven/jsapi-shim": "^0.46.0",
+    "@deephaven/jsapi-utils": "^0.46.0",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react-dom": "^17.0.2",
+    "react-router-dom": "^6.24.0"
   },
   "devDependencies": {
     "@types/react": "^17.0.2",

--- a/src/IFrameApp.tsx
+++ b/src/IFrameApp.tsx
@@ -1,12 +1,12 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { LoadingOverlay } from "@deephaven/components"; // Use the loading spinner from the Deephaven components package
-import {
-  IrisGrid,
-  IrisGridModel,
-  IrisGridModelFactory,
-} from "@deephaven/iris-grid"; // iris-grid is used to display Deephaven tables
 import dh from "@deephaven/jsapi-shim"; // Import the shim to use the JS API
 import "./App.scss"; // Styles for in this app
+import {
+  LOGIN_OPTIONS_REQUEST,
+  isMessage,
+  makeResponse,
+} from "@deephaven/jsapi-utils";
 
 const CLIENT_TIMEOUT = 60_000;
 
@@ -15,6 +15,9 @@ const API_URL = import.meta.env.VITE_DEEPHAVEN_API_URL ?? "";
 const USER = import.meta.env.VITE_DEEPHAVEN_USER ?? "";
 
 const PASSWORD = import.meta.env.VITE_DEEPHAVEN_PASSWORD ?? "";
+
+const WIDTH = 800;
+const HEIGHT = 600;
 
 /**
  * Wait for Deephaven client to be connected
@@ -44,11 +47,10 @@ function clientConnected(client: any): Promise<void> {
  * Needs to listen for when queries are added to the list as they are not known immediately after connecting.
  * @param client The Deephaven client object
  * @param queryName Name of the query to load
- * @param tableName Name of the table to load
  * @returns Deephaven table
  */
-function loadTable(client: any, queryName: string, tableName: string) {
-  console.log(`Fetching query ${queryName}, table ${tableName}...`);
+function getQuery(client: any, queryName: string): Promise<any> {
+  console.log(`Fetching query ${queryName}`);
 
   return new Promise((resolve, reject) => {
     let removeListener: () => void;
@@ -62,7 +64,7 @@ function loadTable(client: any, queryName: string, tableName: string) {
       const matchingQuery = queries.find((query) => query.name === queryName);
 
       if (matchingQuery) {
-        resolve(matchingQuery.getTable(tableName));
+        resolve(matchingQuery);
         clearTimeout(timeout);
         removeListener();
       }
@@ -83,71 +85,20 @@ function loadTable(client: any, queryName: string, tableName: string) {
 }
 
 /**
- * Create a new Deephaven table with the session provided.
- * Creates a table that will tick once every second, with two columns:
- * - Timestamp: The timestamp of the tick
- * - A: The row number
- * @param client The Deephaven client object
- * @param name Name of the table to load
- * @returns Deephaven table
- */
-async function createTable(client: any) {
-  // Create a new session... API is currently undocumented and subject to change in future revisions
-  const ide = new dh.Ide(client);
-
-  // Create a default config
-  const config = new dh.ConsoleConfig();
-
-  // Set configuration parameters here if you don't want the default
-  // config.maxHeapMb = 2048;
-  // config.jvmProfile = ...;
-  // config.jvmArgs = ...;
-  // config.envVars = ...;
-  // config.classpath = ...;
-  // config.dispatcherHost = ...;
-  // config.dispatcherPort = ...;
-
-  console.log("Creating console with config ", config);
-
-  const dhConsole = await ide.createConsole(config);
-
-  console.log("Creating session...");
-
-  // Specify the language, 'python' or 'groovy'
-  const session = await dhConsole.startSession("python");
-
-  // Run the code in the session to open a table
-
-  console.log(`Creating table...`);
-
-  // Run the code you want to run. This example just creates a timeTable
-  await session.runCode("from deephaven.TableTools import timeTable");
-  const result = await session.runCode(
-    't = timeTable("00:00:01").update("A=i")'
-  );
-
-  // Get the new table definition from the results
-  // Results also includes modified/removed objects, which doesn't apply in this case
-  const definition = result.changes.created[0];
-
-  console.log(`Fetching table ${definition.name}...`);
-
-  return await session.getObject(definition);
-}
-
-/**
- * A functional React component that displays a Deephaven table in an IrisGrid using the @deephaven/iris-grid package.
- * If the query param `tableName` is provided, it will attempt to open and display that table, expecting it to be present on the server.
- * E.g. http://localhost:3000/?tableName=myTable will attempt to open a table `myTable`
- * If no query param is provided, it will attempt to open a new session and create a basic time table and display that.
+ * A functional React component that opens an IFrame to a table in a specified Core+ PQ. Will pass the authentication details to the IFrame so it does not need to login.
+ * Query params are required in the URL:
+ * - `query`: Name of the query to open.
+ * - `widget`: Name of the widget to open. Could be a table, figure, or any type of widget.
+ * E.g. http://localhost:3000/iframe/?query=DemoQuery&widget=my_table will attempt to open a table `my_table` from the `DemoQuery` Persistent Query.
  * By default, tries to connect to the server defined in the REACT_APP_CORE_API_URL variable, which is set to http://localhost:8123/irisapi
  * See create-react-app docs for how to update these env vars: https://create-react-app.dev/docs/adding-custom-environment-variables/
  */
 function App() {
-  const [model, setModel] = useState<IrisGridModel>();
+  const [iframeUrl, setIframeUrl] = useState<string>();
   const [error, setError] = useState<string>();
   const [isLoading, setIsLoading] = useState(true);
   const [client, setClient] = useState<any>();
+  const iframeRef = React.useRef<HTMLIFrameElement>(null);
 
   const initApp = useCallback(async () => {
     try {
@@ -173,24 +124,30 @@ function App() {
 
       // Get the table name from the search params `queryName` and `tableName`.
       const searchParams = new URLSearchParams(window.location.search);
-      const queryName = searchParams.get("queryName");
-      const tableName = searchParams.get("tableName");
+      const queryName = searchParams.get("queryName") ?? "";
+      const widgetName = searchParams.get("widgetName") ?? "";
+      if (queryName === "" || widgetName === "") {
+        throw new Error(
+          "Missing query or widget name in URL. Please provide the 'queryName' and 'widgetName' query params in the URL."
+        );
+      }
 
-      // If a table name was specified, load that table. Otherwise, create a new table.
-      const table = await (queryName && tableName
-        ? loadTable(client, queryName, tableName)
-        : createTable(client));
+      // Get the PQ specified by the query name
+      const query = await getQuery(client, queryName);
+      console.log("Query successfully loaded!", query);
 
-      // Create the `IrisGridModel` for use with the `IrisGrid` component
-      console.log(`Creating model...`);
-
-      const newModel = await IrisGridModelFactory.makeModel(dh, table);
-
-      setModel(newModel);
-
-      console.log("Table successfully loaded!");
+      // Build the URL for the IFrame URL
+      // ../iframe/widget/ is the path to the IFrame widget relative to the IDE Url
+      // The authProvider=parent parameter tells the IFrame to use the parent's (e.g. this window's) authentication.
+      // The name parameter specifies the widget to open
+      const newUrl = new URL(
+        `../iframe/widget/?authProvider=parent&name=${widgetName}`,
+        query.ideUrl
+      );
+      console.log("Setting IFrame URL to", newUrl.href);
+      setIframeUrl(newUrl.href);
     } catch (e) {
-      console.error("Unable to load table", e);
+      console.error("Unable to find query", e);
       setError(`${e}`);
     }
     setIsLoading(false);
@@ -207,11 +164,66 @@ function App() {
     };
   }, [client]);
 
-  const isLoaded = model != null;
+  /**
+   * Handle an authentication request.
+   * First check if it's from the IFrame, and if it is a valid request, generate an auth token and send it to the IFrame.
+   */
+  const handleAuthentication = useCallback(
+    async (event: MessageEvent<unknown>) => {
+      const { data, source, origin } = event;
+      // Check that it's coming from the IFrame we created
+      if (
+        source == null ||
+        iframeRef.current == null ||
+        source !== iframeRef.current?.contentWindow
+      ) {
+        console.log("Ignore message, invalid event source", source);
+        return;
+      }
+
+      // Check if it's a message that we recognize
+      if (!isMessage(data) || data.message !== LOGIN_OPTIONS_REQUEST) {
+        console.log("Ignore message, invalid message", data);
+        return;
+      }
+
+      // Create the auth token to send back
+      const token = await client.createAuthToken("RemoteQueryProcessor");
+
+      // Create the LoginOptions object to send back
+      const loginOptions = {
+        type: "io.deephaven.proto.auth.Token",
+        token,
+      };
+
+      // Send the token back to the IFrame
+      source.postMessage(makeResponse(data.id, loginOptions), origin);
+    },
+    [client]
+  );
+
+  // Wire up our listener for authentication requests
+  useEffect(() => {
+    window.addEventListener("message", handleAuthentication);
+    return () => {
+      window.removeEventListener("message", handleAuthentication);
+    };
+  }, [handleAuthentication]);
+
+  const isLoaded = iframeUrl != null;
 
   return (
     <div className="App">
-      {isLoaded && <IrisGrid model={model} />}
+      <h1>Deephaven IFrame</h1>
+      {isLoaded && (
+        <iframe
+          src={iframeUrl}
+          title="Deephaven IFrame"
+          width={WIDTH}
+          height={HEIGHT}
+          ref={iframeRef}
+        />
+      )}
       {!isLoaded && (
         <LoadingOverlay
           isLoaded={isLoaded}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,13 +1,26 @@
 import React from "react";
 import ReactDOM from "react-dom";
+import { RouterProvider, createBrowserRouter } from "react-router-dom";
 
 // Need to import the base style sheet for proper styling
 import "@deephaven/components/scss/BaseStyleSheet.scss";
 import App from "./App";
+import IFrameApp from "./IFrameApp";
+
+const router = createBrowserRouter([
+  {
+    path: "/",
+    element: <App />,
+  },
+  {
+    path: "/iframe",
+    element: <IFrameApp />,
+  },
+]);
 
 ReactDOM.render(
   <React.StrictMode>
-    <App />
+    <RouterProvider router={router} />
   </React.StrictMode>,
   document.getElementById("root")
 );


### PR DESCRIPTION
- Takes queryName and widgetName as URL params and loads the specified widget into an IFrame
- Handles authentication request from the IFrame in the parent window
- There's a few things we can do to improve this experience going forward:
  - Publish the Enterprise JSAPI types
  - Publish utility functions for handling the authentication request, and/or generating the IFrame URL based on the client, query, and widget name
